### PR TITLE
Fixed to recover icons when Explorer crashes

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -20,8 +20,17 @@ Window::~Window(void)
 
 LRESULT CALLBACK Window::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
+	static UINT s_uTaskbarRestart = WM_NULL;
+	// When TaskbarRestart
+	if (message != WM_NULL && message == s_uTaskbarRestart) {
+		notifyIcon.reset();
+		notifyIcon.reset(new NotifyIcon(GetModuleHandle(NULL), hwnd));
+	}
+
     switch (message)
     {
+	case WM_CREATE:
+		s_uTaskbarRestart = RegisterWindowMessage(_T("TaskbarCreated"));
     case WM_SYSCOMMAND:
         switch (wParam)
         {


### PR DESCRIPTION
## Describe the bug
When Explorer crashes, the icon is not displayed.

## To Reproduce
Steps to reproduce the behavior:

1. Open `Task Manager` and Kill or Restart `explorer.exe`.
2. In `Task Manager` run explorer.exe.

## Expected behavior
Expect if explorer.exe crashes that the WinK760 System Tray (Notification Area) Icon would return when explorer.exe recovers.

## System information

- Windows 11 23H2

## Additional context
Fix is at https://learn.microsoft.com/en-us/windows/win32/shell/taskbar?redirectedfrom=MSDN#taskbar-creation-notification, 
see section "Taskbar Creation Notification", need to listen for the TaskbarCreated event.